### PR TITLE
Fixed sidebar

### DIFF
--- a/django_task/static/task/css/common.css
+++ b/django_task/static/task/css/common.css
@@ -81,7 +81,7 @@ h1 {
     float: left;
     background-color: #99CCFF;
     display: inline;
-    width: 20%;
+    /* width: 20%; */
 }
 
 #projects-list {


### PR DESCRIPTION
Sidebar was not parallel to content bar due to content width + sidebar width + padding going over total page width. Removed sidebar width entirely.
